### PR TITLE
Use more descriptive value than foo in tests

### DIFF
--- a/test/api/slack/post_event.test.ts
+++ b/test/api/slack/post_event.test.ts
@@ -43,7 +43,7 @@ describe('POST /api/slack/event', () => {
                 type: 'event_callback',
                 subtype: 'not a file share',
                 team_id: 'T001',
-                event: { thread_ts: 'foo' }
+                event: { thread_ts: 'foo-thread-ts' }
             };
 
             it('will be ignored', () => {

--- a/test/api/slack/post_interaction.test.ts
+++ b/test/api/slack/post_interaction.test.ts
@@ -179,7 +179,7 @@ describe('POST /api/slack/interaction', () => {
                     'private_metadata': 'support_bug',
                     'user': {
                         'id': 'UHAV00MD0',
-                        'username': 'foo',
+                        'username': 'foo-username',
                         'name': 'bar',
                         'team_id': 'THS7JQ2RL'
                     },
@@ -228,7 +228,7 @@ describe('POST /api/slack/interaction', () => {
                     'private_metadata': 'support_data',
                     'user': {
                         'id': 'UHAV00MD0',
-                        'username': 'foo',
+                        'username': 'foo-username',
                         'name': 'bar',
                         'team_id': 'THS7JQ2RL'
                     },
@@ -326,9 +326,9 @@ describe('POST /api/slack/interaction', () => {
             },
             channel: {
                 id: 'CHNBT34FJ',
-                name: 'foobar'
+                name: 'foobar-channel'
             },
-            callback_id: 'foo bar',
+            callback_id: 'foo-callback-id',
             response_url: 'https://hooks.slack.com/app/response_url'
         };
 
@@ -423,9 +423,9 @@ describe('POST /api/slack/interaction', () => {
             },
             channel: {
                 id: 'CHNBT34FJ',
-                name: 'foobar'
+                name: 'foo-channel'
             },
-            callback_id: 'foo bar',
+            callback_id: 'foo-callback-id',
             response_url: 'https://hooks.slack.com/app/response_url'
         };
 

--- a/test/lib/product_config.test.ts
+++ b/test/lib/product_config.test.ts
@@ -4,7 +4,7 @@ const featureSpy = jest.spyOn(feature, 'is_enabled');
 import productConfig from '../../src/lib/product_config';
 
 describe('productConfig', () => {
-    const slack_user = { id: 'foo', name: 'Joe Doe' };
+    const slack_user = { id: 'foo-user-id', name: 'Joe Doe' };
     describe('default', () => {
         const config = productConfig('default');
         it('exists', () => {

--- a/test/lib/slack.test.ts
+++ b/test/lib/slack.test.ts
@@ -37,7 +37,7 @@ describe('Slack', () => {
         };
         const request_type = 'bug';
         const message_text = supportMessageText(submission, user, request_type);
-        const channel_id = 'foo';
+        const channel_id = 'foo-channel-id';
 
         it('returns a Promise that resolves to SlackMessage', (done) => {
             expect.assertions(1);

--- a/test/lib/support_config.test.ts
+++ b/test/lib/support_config.test.ts
@@ -1,7 +1,7 @@
 import supportConfig from '../../src/lib/support_config';
 
 describe('supportConfig', () => {
-    const slack_user = { id: 'foo', name: 'Joe Doe' };
+    const slack_user = { id: 'foo-user-id', name: 'Joe Doe' };
     describe('default', () => {
         const config = supportConfig('default');
         it('exists', () => {


### PR DESCRIPTION
Locally the issue was with jest using .env instead of .env.example for loading configuration.