### PR TITLE
Fix CI failing test

### DIFF
--- a/test/api/jira.test.ts
+++ b/test/api/jira.test.ts
@@ -34,8 +34,14 @@ describe('POST /api/jira/event/:team_id', () => {
             });
     }
 
-    it('returns 200 OK', () => {
-        return service(params).expect(200);
+    it('returns 200 OK', (done) => {
+        service(params).expect(200).end((err) => {
+            if (err) {
+                return done(err);
+            }
+
+            done();
+        });
     });
 
     it('returns empty', (done) => {


### PR DESCRIPTION
Timeout - Async callback was not invoked within the 250 ms timeout
specified by jest.setTimeout.Timeout - Async callback was not invoked
within the 250 ms timeout specified by jest.setTimeout.Error

Relates to https://github.com/Syft-Application/podpora-bot/issues/187